### PR TITLE
Fix CI: pin automerge-action to a release tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Merge the pull request
-        uses: 'pascalgn/automerge-action@f81beb99aef41bb55ad072857d43073fba833a98'
+        uses: 'pascalgn/automerge-action@v0.16.4'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
## Summary

CI on #161 was failing at the "Merge the pull request" step with:

```
error tmp@0.2.7: The engine "node" is incompatible with this module. Expected version ">=14.14". Got "11.15.0"
```

The workflow pinned `pascalgn/automerge-action` to a raw commit SHA rather than a release tag. GitHub Actions can't resolve a pre-built Docker image for an arbitrary commit, so it rebuilds the action's Dockerfile from scratch every run. That Dockerfile uses `node:11-alpine`, and one of the action's npm dependencies (`tmp`) has since raised its minimum required Node version to 14.14+, breaking the build on every PR — unrelated to any specific PR's changes.

Switches the pin to the latest release, `v0.16.4`, which has a published image on Docker Hub and skips the broken rebuild.

## Test plan

- [x] CI on this PR should now pass the automerge-action build step