### PR TITLE
Add explicit read-only permissions to CI/CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,6 +7,9 @@ on:
     types: [closed]
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: Continuous Integration
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Fixes CodeQL code scanning alerts [#1](https://github.com/carpiediem/carpiediem.github.io/security/code-scanning/1) and [#2](https://github.com/carpiediem/carpiediem.github.io/security/code-scanning/2) (`actions/missing-workflow-permissions`): neither `ci.yml` nor `cd.yml` declared explicit `permissions`, so their `GITHUB_TOKEN` fell back to the repo/org default, which may be broader (read-write) than needed.

- Both workflows only checkout, install, and run tests/lint/coverage — no write access needed.
- `cd.yml`'s deploy step pushes to the `gh-pages` branch using its own `ACTIONS_DEPLOY_ACCESS_TOKEN` secret, not `GITHUB_TOKEN`, so restricting `GITHUB_TOKEN` to `contents: read` doesn't affect deploys.

## Test plan

- [x] `npx prettier --check .github/workflows/ci.yml .github/workflows/cd.yml`
- [x] CI passes on this PR (workflow itself is the thing being changed, so this is the real verification)