### PR TITLE
Add regression test for invalid element type errors

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,9 +1,36 @@
 import React from "react";
 import { render } from "@testing-library/react";
+import { vi } from "vitest";
 import App from "./App";
+import projects from "./content/projects.json";
 
 test("renders Home screen, by default", () => {
   const { getByTestId } = render(<App />);
   const homeDiv = getByTestId("home");
   expect(homeDiv).toBeInTheDocument();
+});
+
+// Guards against regressions like React error #130 (invalid element
+// type - e.g. an icon import resolving to a module object instead of
+// a component), which silently render a blank page instead of
+// throwing. This checks for that failure class specifically, rather
+// than requiring zero console output, since unrelated deprecation
+// warnings are expected noise on older dependency versions.
+function expectNoInvalidElementTypeErrors(path) {
+  const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+  window.history.pushState({}, "", path);
+  render(<App />);
+  const invalidElementErrors = spy.mock.calls.filter(([message]) =>
+    String(message).includes("Element type is invalid"),
+  );
+  expect(invalidElementErrors).toEqual([]);
+  spy.mockRestore();
+}
+
+test("renders the home page without invalid element type errors", () => {
+  expectNoInvalidElementTypeErrors("/");
+});
+
+test("renders a project page without invalid element type errors", () => {
+  expectNoInvalidElementTypeErrors(`/projects/${projects[0].id}`);
 });


### PR DESCRIPTION
## Summary
- Follow-up to #166, which fixed the blank-page bug (React error #130) but merged before this test was added.
- Adds two tests to `App.test.jsx` that render the home and project routes and fail if React logs an "Element type is invalid" error — the specific failure mode behind that bug, which happens whenever an import silently resolves to a module object instead of a component.
- Uses a targeted check (filtering for that error message) rather than zero-tolerance on console output, since unrelated MUI v4 deprecation warnings are expected noise on this dependency version.

## Test plan
- [x] `npm test` — 36/36 passing, including the two new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)