### PR TITLE
Add ESLint step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Check formatting
         run: npm run format:check
 
+      - name: Run ESLint
+        run: npm run lint
+
       - name: Run the tests
         run: npm test -- --coverage
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "start": "vite",
     "build": "vite build",
     "test": "vitest run",
+    "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "predeploy": "npm run build",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "start": "vite",
     "build": "vite build",
     "test": "vitest run",
-    "lint": "eslint .",
+    "lint": "eslint . --ext .js,.jsx",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "predeploy": "npm run build",

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -117,7 +117,7 @@ const useStyles = makeStyles((theme) => ({
   hello: { color: "black", fontSize: 20, fontWeight: 300 },
 }));
 
-export default forwardRef((props, ref) => {
+const About = forwardRef((props, ref) => {
   const classes = useStyles();
 
   const triggerDownloadEvent = () =>
@@ -234,3 +234,6 @@ export default forwardRef((props, ref) => {
     </React.Fragment>
   );
 });
+About.displayName = "About";
+
+export default About;

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -6,7 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import School from "./School";
 import schools from "../content/schools.json";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     maxWidth: 960,
     padding: "0 15px",
@@ -29,7 +29,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default forwardRef((props, ref) => {
+const Education = forwardRef((props, ref) => {
   const classes = useStyles();
 
   return (
@@ -48,3 +48,6 @@ export default forwardRef((props, ref) => {
     </section>
   );
 });
+Education.displayName = "Education";
+
+export default Education;

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -6,7 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import Job from "./Job";
 import jobs from "../content/jobs.json";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     maxWidth: 960,
     padding: "0 15px",
@@ -30,7 +30,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default forwardRef((props, ref) => {
+const Experience = forwardRef((props, ref) => {
   const classes = useStyles();
 
   return (
@@ -49,3 +49,6 @@ export default forwardRef((props, ref) => {
     </section>
   );
 });
+Experience.displayName = "Experience";
+
+export default Experience;

--- a/src/components/Introduction.jsx
+++ b/src/components/Introduction.jsx
@@ -4,7 +4,7 @@ import Typography from "@material-ui/core/Typography";
 
 // import SpeechBubble from './SpeechBubble';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     paddingBottom: 15,
     borderBottom: "thin solid #ddd",

--- a/src/components/Portfolio.jsx
+++ b/src/components/Portfolio.jsx
@@ -82,7 +82,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default forwardRef((props, ref) => {
+const Portfolio = forwardRef((props, ref) => {
   const classes = useStyles();
 
   const scrollUp = () => window.scrollTo(0, 0);
@@ -165,3 +165,6 @@ export default forwardRef((props, ref) => {
     </section>
   );
 });
+Portfolio.displayName = "Portfolio";
+
+export default Portfolio;

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -6,7 +6,7 @@ import Typography from "@material-ui/core/Typography";
 import Skill from "./Skill";
 import skills from "../content/skills.json";
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   root: {
     maxWidth: 960,
     padding: "0 15px",
@@ -32,7 +32,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default forwardRef((props, ref) => {
+const Skills = forwardRef((props, ref) => {
   const classes = useStyles();
 
   return (
@@ -52,3 +52,6 @@ export default forwardRef((props, ref) => {
     </section>
   );
 });
+Skills.displayName = "Skills";
+
+export default Skills;

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -11,22 +11,27 @@ import Education from "../components/Education";
 export default function Home() {
   const [section, setSection] = useState(null);
 
-  // MUST BE IN REVERSE ORDER
-  const refs = {
-    education: useRef(null),
-    experience: useRef(null),
-    portfolio: useRef(null),
-    skills: useRef(null),
-    about: useRef(null),
-  };
+  const educationRef = useRef(null);
+  const experienceRef = useRef(null);
+  const portfolioRef = useRef(null);
+  const skillsRef = useRef(null);
+  const aboutRef = useRef(null);
 
   useEffect(() => {
-    const breakpoints = Object.entries(refs).map(([key, ref]) => [
+    // MUST BE IN REVERSE ORDER
+    const sections = [
+      ["education", educationRef],
+      ["experience", experienceRef],
+      ["portfolio", portfolioRef],
+      ["skills", skillsRef],
+      ["about", aboutRef],
+    ];
+    const breakpoints = sections.map(([key, ref]) => [
       key,
       window.scrollY + ref.current.getBoundingClientRect().top,
     ]);
     const listener = debounce(() => {
-      const section = breakpoints.find(([key, y]) => window.scrollY + 99 >= y);
+      const section = breakpoints.find(([, y]) => window.scrollY + 99 >= y);
       setSection(section && section[0]);
     }, 100);
 
@@ -37,11 +42,11 @@ export default function Home() {
   return (
     <div data-testid="home">
       <NavBar section={section} />
-      <About ref={refs.about} />
-      <Skills ref={refs.skills} />
-      <Portfolio ref={refs.portfolio} />
-      <Experience ref={refs.experience} />
-      <Education ref={refs.education} />
+      <About ref={aboutRef} />
+      <Skills ref={skillsRef} />
+      <Portfolio ref={portfolioRef} />
+      <Experience ref={experienceRef} />
+      <Education ref={educationRef} />
     </div>
   );
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,6 +3,9 @@ import react from "@vitejs/plugin-react";
 
 export default defineConfig({
   plugins: [react()],
+  esbuild: {
+    logOverride: { "duplicate-object-key": "silent" },
+  },
   build: {
     outDir: "build",
   },


### PR DESCRIPTION
## Summary
- Add an `npm run lint` script and a CI step that runs it on every push
- Fix the two issues it initially surfaced in `About.jsx` (missing forwardRef display name) and `vite.config.js` (silence the intentional duplicate-key esbuild warning used as a CSS gradient fallback)
- Discovered the lint script's `eslint .` was silently skipping all `.jsx` files (ESLint 8 legacy mode only lints `.js` by default without `--ext`) — added `--ext .js,.jsx` and fixed everything that surfaced:
  - Unused `theme` params in `Education`, `Experience`, `Introduction`, `Skills`
  - Missing `displayName` on the `forwardRef`-wrapped `Education`, `Experience`, `Skills`, `Portfolio` components
  - A `react-hooks/refs` false positive in `Home.jsx`, caused by passing refs through a plain object (`refs.skills`) instead of individual `useRef()` bindings — refactored to named refs, preserving the reverse-order scroll-breakpoint logic
  - An unused destructured `key` in a `.find()` callback in `Home.jsx`

## Test plan
- [x] `npm run lint` passes clean
- [x] `npm run format:check` passes clean
- [x] `npm test` — 34 tests pass
- [x] `npx vite build` succeeds with no warnings from the fixed issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)