### PR TITLE
Scroll to URL hash section on first load

### DIFF
--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -18,6 +18,16 @@ export default function Home() {
   const aboutRef = useRef(null);
 
   useEffect(() => {
+    // The browser's native same-page anchor scroll only fires once, when
+    // the URL is first processed. On first load that happens before React
+    // has rendered the named anchors, so it's a no-op; do it ourselves
+    // once the page has rendered instead.
+    const hash = window.location.hash.slice(1);
+    const target = hash && document.getElementsByName(hash)[0];
+    if (target) target.scrollIntoView();
+  }, []);
+
+  useEffect(() => {
     // MUST BE IN REVERSE ORDER
     const sections = [
       ["education", educationRef],


### PR DESCRIPTION
## Summary
- Branched from #169 (MUI/React 18 upgrade), targeting that branch.
- Fixes: visiting `/#experience` (or any `/#section`) directly does nothing on first load, even though editing the hash after the page has already rendered scrolls correctly.
- Cause: the browser's native same-page anchor scroll only runs once, at the moment it first processes the URL - which happens before React has rendered the named `<a name="...">` anchors on a cold load. Editing the hash later works because the anchors already exist in the DOM by then.
- Fix: a `useEffect` in `Home.jsx` that runs once after mount, looks up `document.getElementsByName(hash)`, and calls `scrollIntoView()` if a match exists - replicating the native behavior after React has actually rendered.

## Test plan
- [x] Verified headless via Playwright: loading `http://localhost:5173/#experience` fresh scrolls the Experience section to the top of the viewport; loading with no hash leaves scroll at 0
- [x] `npm test` - 36/36 passing
- [x] `npm run build` / `npm run lint` - clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)