### PR TITLE
Code-split the project route and write-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Source for my personal site, live at **[carpiediem.github.io](https://carpiediem
 
 ## Tech stack
 
-- [React](https://react.dev/) 16 + [Vite](https://vite.dev/)
-- [Material-UI](https://v4.mui.com/) v4
+- [React](https://react.dev/) 18 + [Vite](https://vite.dev/)
+- [MUI](https://mui.com/) v9
 - [React Router](https://v5.reactrouter.com/)
 - [Vitest](https://vitest.dev/) for tests
 - Deployed to GitHub Pages via [gh-pages](https://github.com/tschaub/gh-pages)
@@ -21,7 +21,7 @@ npm install
 npm start
 ```
 
-Runs the app locally at [http://localhost:3000](http://localhost:3000).
+Runs the app locally at [http://localhost:5173](http://localhost:5173).
 
 Other scripts:
 
@@ -40,7 +40,7 @@ To add a portfolio project, add an entry to `projects.json` and drop the corresp
 
 ## Acknowledgements
 
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app). The RScard designs of [PXlab](https://rscard.px-lab.com/) were a big inspiration.
+This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app) and later migrated to [Vite](https://vite.dev/). The RScard designs of [PXlab](https://rscard.px-lab.com/) were a big inspiration.
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "carpiediem.github.io",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "carpiediem.github.io",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "^11.14.0",
@@ -7535,22 +7535,6 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,12 @@
 import "core-js/stable";
 import "regenerator-runtime/runtime";
-import React from "react";
+import React, { Suspense, lazy } from "react";
 import { BrowserRouter, Switch, Route } from "react-router-dom";
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 
 import Home from "./screens/Home";
-import Project from "./screens/Project";
+
+const Project = lazy(() => import("./screens/Project"));
 
 function App() {
   // https://coolors.co/006d77-83c5be-edf6f9-ffddd2-e29578
@@ -36,7 +37,9 @@ function App() {
       <BrowserRouter>
         <Switch>
           <Route path="/projects/:id">
-            <Project />
+            <Suspense fallback={null}>
+              <Project />
+            </Suspense>
           </Route>
           <Route path="/">
             <Home />

--- a/src/screens/Project.jsx
+++ b/src/screens/Project.jsx
@@ -47,7 +47,10 @@ export default function Project() {
   useEffect(() => {
     let cancelled = false;
     const writeUpKey = `../content/${id}.html`;
-    const hasOwnWriteUp = Object.prototype.hasOwnProperty.call(writeUps, writeUpKey);
+    const hasOwnWriteUp = Object.prototype.hasOwnProperty.call(
+      writeUps,
+      writeUpKey,
+    );
     const candidateLoader = hasOwnWriteUp ? writeUps[writeUpKey] : undefined;
     const loadWriteUp =
       typeof candidateLoader === "function"

--- a/src/screens/Project.jsx
+++ b/src/screens/Project.jsx
@@ -46,9 +46,13 @@ export default function Project() {
 
   useEffect(() => {
     let cancelled = false;
+    const writeUpKey = `../content/${id}.html`;
+    const hasOwnWriteUp = Object.prototype.hasOwnProperty.call(writeUps, writeUpKey);
+    const candidateLoader = hasOwnWriteUp ? writeUps[writeUpKey] : undefined;
     const loadWriteUp =
-      writeUps[`../content/${id}.html`] ??
-      (() => Promise.resolve("<p>TBD</p>"));
+      typeof candidateLoader === "function"
+        ? candidateLoader
+        : () => Promise.resolve("<p>TBD</p>");
     loadWriteUp().then((html) => {
       if (!cancelled) setContent(html);
     });

--- a/src/screens/Project.jsx
+++ b/src/screens/Project.jsx
@@ -56,6 +56,14 @@ export default function Project() {
       typeof candidateLoader === "function"
         ? candidateLoader
         : () => Promise.resolve("<p>TBD</p>");
+    // CodeQL flags this as js/unvalidated-dynamic-method-call - a known
+    // false positive for import.meta.glob() lookups like this one. writeUps
+    // is a closed, build-time-generated object whose values are always glob
+    // loader functions, never anything reachable via prototype pollution or
+    // otherwise unsafe to invoke; the hasOwnProperty + typeof guards above
+    // already rule out calling anything else. This is purely client-side
+    // (id is a URL param the same visitor controls in their own tab), so
+    // there's no privilege boundary being crossed either.
     loadWriteUp().then((html) => {
       if (!cancelled) setContent(html);
     });

--- a/src/screens/Project.jsx
+++ b/src/screens/Project.jsx
@@ -14,7 +14,6 @@ import NavBar from "../components/NavBar";
 import projects from "../content/projects.json";
 
 const writeUps = import.meta.glob("../content/*.html", {
-  eager: true,
   query: "?raw",
   import: "default",
 });
@@ -43,7 +42,20 @@ export default function Project() {
 
   const summary = projects.find((p) => p.id === id);
 
-  const content = writeUps[`../content/${id}.html`] ?? "<p>TBD</p>";
+  const [content, setContent] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    const loadWriteUp =
+      writeUps[`../content/${id}.html`] ??
+      (() => Promise.resolve("<p>TBD</p>"));
+    loadWriteUp().then((html) => {
+      if (!cancelled) setContent(html);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
 
   useEffect(() => {
     const listener = debounce(() => {


### PR DESCRIPTION
## Summary
- The production build was a single 648KB (216KB gzip) chunk containing everything, including all 21 project write-up HTML files bundled eagerly via `import.meta.glob(..., { eager: true })` - downloaded by every visitor even if they never open a project page.
- Lazy-loads the `/projects/:id` screen with `React.lazy` + `Suspense`.
- Switches the write-up glob from eager to lazy, so each project's HTML content is its own on-demand chunk instead of all of them being bundled up front.
- Net effect: initial bundle drops to 608KB; the removed content is now split across ~20 tiny (0.04-10KB) chunks fetched only when a specific project page is visited.
- Also fixed stale README references left over from the CRA -> Vite and MUI v4 -> v9 migrations (React 16 -> 18, Material-UI v4 -> MUI v9, port 3000 -> 5173, bootstrapped-with-CRA note).

## Test plan
- [x] `npm test` - 36/36 passing
- [x] `npm run build` / `npm run lint` - clean
- [x] Verified headless via Playwright: `/projects/gameofthrones` still renders full write-up content after the switch to lazy loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)