### PR TITLE
Prerender routes to static HTML for SEO and direct-link support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # production
 /build
+/build-ssr
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "vite build",
+    "build": "vite build && vite build --ssr src/entry-server.jsx --outDir build-ssr && node scripts/prerender.mjs",
     "test": "vitest run",
     "lint": "eslint . --ext .js,.jsx",
     "format": "prettier --write .",
@@ -97,6 +97,7 @@
     "ignorePatterns": [
       "**/*.html",
       "build",
+      "build-ssr",
       "coverage",
       "public"
     ]

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,0 +1,60 @@
+// Renders every route to static HTML after the client build, so GitHub
+// Pages serves real content (crawlers, no-JS clients, first paint)
+// instead of an empty <div id="root">. The client bundle still boots
+// and takes over normally once it loads - see src/entry-server.jsx for
+// why this doesn't attempt real hydration.
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const rootDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const buildDir = path.join(rootDir, "build");
+
+function escapeHtml(text) {
+  return text.replace(
+    /[&<>"']/g,
+    (char) =>
+      ({
+        "&": "&amp;",
+        "<": "&lt;",
+        ">": "&gt;",
+        '"': "&quot;",
+        "'": "&#39;",
+      })[char],
+  );
+}
+
+function outputPathFor(url) {
+  return url === "/"
+    ? path.join(buildDir, "index.html")
+    : path.join(buildDir, url.replace(/^\/+/, ""), "index.html");
+}
+
+async function main() {
+  const { render, routes, metaFor } = await import(
+    path.join(rootDir, "build-ssr", "entry-server.js")
+  );
+
+  const template = await readFile(path.join(buildDir, "index.html"), "utf-8");
+
+  for (const url of routes()) {
+    const appHtml = render(url);
+    const { title, description } = metaFor(url);
+
+    const html = template
+      .replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`)
+      .replace(/<title>.*<\/title>/, `<title>${escapeHtml(title)}</title>`)
+      .replace(
+        /<meta name="description" content="[^"]*" \/>/,
+        `<meta name="description" content="${escapeHtml(description)}" />`,
+      );
+
+    const outputPath = outputPathFor(url);
+    await mkdir(path.dirname(outputPath), { recursive: true });
+    await writeFile(outputPath, html);
+  }
+
+  console.log(`Prerendered ${routes().length} routes.`);
+}
+
+main();

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -30,6 +30,22 @@ function outputPathFor(url) {
     : path.join(buildDir, url.replace(/^\/+/, ""), "index.html");
 }
 
+// Project.jsx loads its write-up text asynchronously (see that file), which
+// renderToString can't wait on - so read the file directly here and hand it
+// to entry-server.jsx to render synchronously as the initial content.
+async function writeUpContentFor(url) {
+  const match = url.match(/^\/projects\/(.+)$/);
+  if (!match) return undefined;
+  try {
+    return await readFile(
+      path.join(rootDir, "src", "content", `${match[1]}.html`),
+      "utf-8",
+    );
+  } catch {
+    return "<p>TBD</p>";
+  }
+}
+
 async function main() {
   const { render, routes, metaFor } = await import(
     path.join(rootDir, "build-ssr", "entry-server.js")
@@ -38,7 +54,8 @@ async function main() {
   const template = await readFile(path.join(buildDir, "index.html"), "utf-8");
 
   for (const url of routes()) {
-    const appHtml = render(url);
+    const writeUpContent = await writeUpContentFor(url);
+    const appHtml = render(url, { writeUpContent });
     const { title, description } = metaFor(url);
 
     const html = template

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,36 +2,14 @@ import "core-js/stable";
 import "regenerator-runtime/runtime";
 import React, { Suspense, lazy } from "react";
 import { BrowserRouter, Switch, Route } from "react-router-dom";
-import { createTheme, ThemeProvider } from "@mui/material/styles";
+import { ThemeProvider } from "@mui/material/styles";
 
 import Home from "./screens/Home";
+import { theme } from "./theme";
 
 const Project = lazy(() => import("./screens/Project"));
 
 function App() {
-  // https://coolors.co/006d77-83c5be-edf6f9-ffddd2-e29578
-  // 006d77,83c5be,edf6f9,ffddd2,e29578
-  const theme = createTheme({
-    palette: {
-      primary: { main: "#006d77", light: "#83c5be" },
-      secondary: { main: "#e29578", light: "#ffddd2" },
-    },
-    typography: {
-      fontWeight: 400,
-      fontFamily: [
-        '"Open Sans"',
-        '"Segoe UI"',
-        "Roboto",
-        '"Helvetica Neue"',
-        "Arial",
-        "sans-serif",
-        '"Apple Color Emoji"',
-        '"Segoe UI Emoji"',
-        '"Segoe UI Symbol"',
-      ].join(","),
-    },
-  });
-
   return (
     <ThemeProvider theme={theme}>
       <BrowserRouter>

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -57,7 +57,7 @@ const Root = styled("div")(({ theme }) => ({
 
 export default function NavBar(props) {
   const { section } = props;
-  const narrow = window.innerWidth < 600;
+  const narrow = typeof window !== "undefined" && window.innerWidth < 600;
 
   return (
     <Root data-testid="NavBar">

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { renderToString } from "react-dom/server";
+import { StaticRouter, Switch, Route } from "react-router-dom";
+import { ThemeProvider } from "@mui/material/styles";
+
+import Home from "./screens/Home";
+import Project from "./screens/Project";
+import { theme } from "./theme";
+import projects from "./content/projects.json";
+
+// Renders each route eagerly (skipping App.jsx's client-only lazy-loaded
+// Project screen) since renderToString can't wait on Suspense/lazy to
+// resolve - it just flushes the fallback. That's fine here: this bundle
+// is only ever loaded once per prerendered route by scripts/prerender.mjs,
+// never shipped to the browser, so there's no bundle-size cost to eagerly
+// importing everything.
+export function render(url) {
+  return renderToString(
+    <ThemeProvider theme={theme}>
+      <StaticRouter location={url}>
+        <Switch>
+          <Route path="/projects/:id">
+            <Project />
+          </Route>
+          <Route path="/">
+            <Home />
+          </Route>
+        </Switch>
+      </StaticRouter>
+    </ThemeProvider>,
+  );
+}
+
+export function routes() {
+  return ["/", ...projects.map((project) => `/projects/${project.id}`)];
+}
+
+export function metaFor(url) {
+  const match = url.match(/^\/projects\/(.+)$/);
+  const project = match && projects.find((p) => p.id === match[1]);
+  if (!project) {
+    return {
+      title: "Ryan SL Carpenter",
+      description: "Personal web site of Ryan SL Carpenter",
+    };
+  }
+  return {
+    title: `${project.title} - Ryan SL Carpenter`,
+    description: project.title,
+  };
+}

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -14,13 +14,18 @@ import projects from "./content/projects.json";
 // is only ever loaded once per prerendered route by scripts/prerender.mjs,
 // never shipped to the browser, so there's no bundle-size cost to eagerly
 // importing everything.
-export function render(url) {
+//
+// writeUpContent is passed in as initialContent for Project, since that
+// screen loads its write-up text asynchronously (see Project.jsx) -
+// renderToString can't wait on that either, so scripts/prerender.mjs reads
+// the write-up file directly and hands it to us to render synchronously.
+export function render(url, { writeUpContent } = {}) {
   return renderToString(
     <ThemeProvider theme={theme}>
       <StaticRouter location={url}>
         <Switch>
           <Route path="/projects/:id">
-            <Project />
+            <Project initialContent={writeUpContent} />
           </Route>
           <Route path="/">
             <Home />

--- a/src/screens/Project.jsx
+++ b/src/screens/Project.jsx
@@ -36,15 +36,19 @@ const Root = styled("div")(({ theme }) => ({
   },
 }));
 
-export default function Project() {
+export default function Project({ initialContent } = {}) {
   const { id } = useParams();
   const [scrolled, setScrolled] = useState(false);
 
   const summary = projects.find((p) => p.id === id);
 
-  const [content, setContent] = useState("");
+  const [content, setContent] = useState(initialContent ?? "");
 
   useEffect(() => {
+    // initialContent is only ever passed by the SSR entry (see
+    // entry-server.jsx), which already has the real write-up text - no
+    // need to fetch it again client-side for the route the page loaded on.
+    if (initialContent !== undefined) return;
     let cancelled = false;
     const writeUpKey = `../content/${id}.html`;
     const hasOwnWriteUp = Object.prototype.hasOwnProperty.call(
@@ -70,7 +74,7 @@ export default function Project() {
     return () => {
       cancelled = true;
     };
-  }, [id]);
+  }, [id, initialContent]);
 
   useEffect(() => {
     const listener = debounce(() => {

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,24 @@
+import { createTheme } from "@mui/material/styles";
+
+// https://coolors.co/006d77-83c5be-edf6f9-ffddd2-e29578
+// 006d77,83c5be,edf6f9,ffddd2,e29578
+export const theme = createTheme({
+  palette: {
+    primary: { main: "#006d77", light: "#83c5be" },
+    secondary: { main: "#e29578", light: "#ffddd2" },
+  },
+  typography: {
+    fontWeight: 400,
+    fontFamily: [
+      '"Open Sans"',
+      '"Segoe UI"',
+      "Roboto",
+      '"Helvetica Neue"',
+      "Arial",
+      "sans-serif",
+      '"Apple Color Emoji"',
+      '"Segoe UI Emoji"',
+      '"Segoe UI Symbol"',
+    ].join(","),
+  },
+});


### PR DESCRIPTION
## Summary
The site is fully client-rendered, so crawlers (and anything that doesn't run JS, or gives up before it finishes) see only an empty `<div id="root">`, and every route ships the exact same generic `<title>`/meta description. Direct navigation to a `/projects/:id` URL also silently lands on the home page today - GitHub Pages' 404-based SPA fallback (`public/404.html`) has no counterpart script to restore the encoded path before React Router ever sees the real URL.

This adds a build step that renders every route (home + all 16 projects) to real static HTML via `react-dom/server`, written to the matching path - `build/index.html` for `/`, `build/projects/<id>/index.html` per project - with a real per-route `<title>` and meta description. GitHub Pages just serves these as literal files, no server runtime needed, and it incidentally fixes direct-navigation to project URLs since there's now an actual file at that path instead of falling through to the 404 fallback.

**How it works:**
- `src/entry-server.jsx` - a server-only `render(url)` using `renderToString`, plus `routes()` and `metaFor(url)` to drive the prerender step. It renders `Project` eagerly rather than reusing `App.jsx`'s client-only `React.lazy(Project)`, since `renderToString` can't wait on Suspense to resolve (it just flushes the fallback) - only relevant to this Node-only bundle, never shipped to the browser.
- `scripts/prerender.mjs` - builds on the client `build/index.html` template (keeping its real hashed asset tags), swapping in rendered markup/title/description per route.
- `package.json`'s `build` script now does a second `vite build --ssr` pass to get a Node-loadable `entry-server.js`, then runs the prerender script. **No new runtime dependencies** - just `react-dom/server` (already ships with `react-dom`) and Vite's built-in SSR build mode.
- Extracted the theme into `src/theme.js` so `entry-server.jsx` and `App.jsx` share config instead of duplicating it.
- Fixed `NavBar` reading `window.innerWidth` directly during render, which crashes under Node SSR (no `window` global there).

**Known tradeoff:** the client still does a plain `createRoot().render()` CSR pass on top of the prerendered markup, not `hydrateRoot` - true hydration risks mismatches here (e.g. NavBar's narrow-viewport check would disagree between whatever viewport prerendered a page and the actual device loading it). So there's a brief moment where prerendered markup is visible before the client bundle swaps in the fully interactive app, rather than seamless hydration. Happy to revisit if it's worth tightening up.


## Test plan
- [x] `npm test` - 36/36 passing
- [x] `npm run build` / `npm run lint` - clean
- [x] Verified headless via Playwright with JS **disabled**: both `/` and `/projects/gameofthrones` serve real, readable text content
- [x] Verified headless via Playwright with JS **enabled**: client bundle boots normally, stays on the correct route, per-route `<title>` persists after the client render replaces the prerendered markup, zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)