### PR TITLE
Add SEO metadata and accessibility improvements

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,5 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Disallow:
+
+Sitemap: https://carpiediem.github.io/sitemap.xml

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -24,6 +24,32 @@ function escapeHtml(text) {
   );
 }
 
+function seoTagsFor({
+  title,
+  description,
+  canonical,
+  image,
+  type,
+  structuredData,
+}) {
+  const tags = [
+    `<link rel="canonical" href="${escapeHtml(canonical)}" />`,
+    `<meta property="og:type" content="${type}" />`,
+    `<meta property="og:title" content="${escapeHtml(title)}" />`,
+    `<meta property="og:description" content="${escapeHtml(description)}" />`,
+    `<meta property="og:url" content="${escapeHtml(canonical)}" />`,
+    `<meta property="og:image" content="${escapeHtml(image)}" />`,
+    `<meta name="twitter:card" content="summary" />`,
+    `<meta name="twitter:title" content="${escapeHtml(title)}" />`,
+    `<meta name="twitter:description" content="${escapeHtml(description)}" />`,
+    `<meta name="twitter:image" content="${escapeHtml(image)}" />`,
+    // Escape "</" so no field value (e.g. a project title) can prematurely
+    // close this script tag.
+    `<script type="application/ld+json">${JSON.stringify(structuredData).replace(/<\//g, "<\\/")}</script>`,
+  ];
+  return tags.join("\n    ");
+}
+
 function outputPathFor(url) {
   return url === "/"
     ? path.join(buildDir, "index.html")
@@ -46,8 +72,15 @@ async function writeUpContentFor(url) {
   }
 }
 
+function sitemapFor(urls, siteUrl) {
+  const entries = urls
+    .map((url) => `  <url><loc>${siteUrl}${url}</loc></url>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`;
+}
+
 async function main() {
-  const { render, routes, metaFor } = await import(
+  const { render, routes, metaFor, SITE_URL } = await import(
     path.join(rootDir, "build-ssr", "entry-server.js")
   );
 
@@ -56,20 +89,26 @@ async function main() {
   for (const url of routes()) {
     const writeUpContent = await writeUpContentFor(url);
     const appHtml = render(url, { writeUpContent });
-    const { title, description } = metaFor(url);
+    const meta = metaFor(url);
 
     const html = template
       .replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`)
-      .replace(/<title>.*<\/title>/, `<title>${escapeHtml(title)}</title>`)
+      .replace(/<title>.*<\/title>/, `<title>${escapeHtml(meta.title)}</title>`)
       .replace(
         /<meta name="description" content="[^"]*" \/>/,
-        `<meta name="description" content="${escapeHtml(description)}" />`,
-      );
+        `<meta name="description" content="${escapeHtml(meta.description)}" />`,
+      )
+      .replace("</head>", `    ${seoTagsFor(meta)}\n  </head>`);
 
     const outputPath = outputPathFor(url);
     await mkdir(path.dirname(outputPath), { recursive: true });
     await writeFile(outputPath, html);
   }
+
+  await writeFile(
+    path.join(buildDir, "sitemap.xml"),
+    sitemapFor(routes(), SITE_URL),
+  );
 
   console.log(`Prerendered ${routes().length} routes.`);
 }

--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -133,13 +133,22 @@ const About = forwardRef((props, ref) => {
 
   return (
     <Root>
-      <section ref={ref} className="root" data-testid="About">
+      <section
+        ref={ref}
+        className="root"
+        data-testid="About"
+        aria-labelledby="about-heading"
+      >
         <Card className="card" variant="outlined">
           <CardContent className="content">
             <Grid container spacing={3}>
               <Grid size={{ sm: 5 }} className="item">
                 <a name="about" href="#about">
-                  <img alt="" src="/img/ryan.jpg" className="photo" />
+                  <img
+                    alt="Ryan SL Carpenter"
+                    src="/img/ryan.jpg"
+                    className="photo"
+                  />
                 </a>
               </Grid>
               <Grid size={{ sm: 7 }} className="item">
@@ -190,6 +199,7 @@ const About = forwardRef((props, ref) => {
               component="a"
               href="https://www.linkedin.com/in/ryanscarpenter/"
               target="_blank"
+              rel="noopener noreferrer"
             >
               <LinkedInIcon />
             </IconButton>
@@ -198,6 +208,7 @@ const About = forwardRef((props, ref) => {
               component="a"
               href="https://github.com/carpiediem/"
               target="_blank"
+              rel="noopener noreferrer"
             >
               <GitHubIcon />
             </IconButton>
@@ -206,6 +217,7 @@ const About = forwardRef((props, ref) => {
               component="a"
               href="https://angel.co/u/ryanslcarpenter"
               target="_blank"
+              rel="noopener noreferrer"
             >
               <Icon className="fab fa-angellist" />
             </IconButton>
@@ -214,6 +226,7 @@ const About = forwardRef((props, ref) => {
               component="a"
               href="https://stackoverflow.com/users/1811952/carpiediem?tab=profile"
               target="_blank"
+              rel="noopener noreferrer"
             >
               <Icon className="fab fa-stack-overflow" />
             </IconButton>

--- a/src/components/Education.jsx
+++ b/src/components/Education.jsx
@@ -29,8 +29,13 @@ const Root = styled("section")({
 
 const Education = forwardRef((props, ref) => {
   return (
-    <Root ref={ref} data-testid="Education">
-      <Typography variant="h4" component="h2" className="h2">
+    <Root ref={ref} data-testid="Education" aria-labelledby="education-heading">
+      <Typography
+        variant="h4"
+        component="h2"
+        id="education-heading"
+        className="h2"
+      >
         <a name="education" href="#education">
           Education
         </a>

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -30,8 +30,17 @@ const Root = styled("section")({
 
 const Experience = forwardRef((props, ref) => {
   return (
-    <Root ref={ref} data-testid="Experience">
-      <Typography variant="h4" component="h2" className="h2">
+    <Root
+      ref={ref}
+      data-testid="Experience"
+      aria-labelledby="experience-heading"
+    >
+      <Typography
+        variant="h4"
+        component="h2"
+        id="experience-heading"
+        className="h2"
+      >
         <a name="experience" href="#experience">
           Work Experience
         </a>

--- a/src/components/Introduction.jsx
+++ b/src/components/Introduction.jsx
@@ -28,7 +28,12 @@ export default function Introduction(props) {
   return (
     <Root>
       {/* <SpeechBubble text={bubble} /> */}
-      <Typography variant="h4" component="h1" className="name">
+      <Typography
+        variant="h4"
+        component="h1"
+        id="about-heading"
+        className="name"
+      >
         {name}
       </Typography>
       <Typography variant="h6" component="h2" className="role">

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -11,6 +11,14 @@ import PortfolioIcon from "@mui/icons-material/PhotoLibrary";
 import ExperienceIcon from "@mui/icons-material/Work";
 import EducationIcon from "@mui/icons-material/School";
 
+const sections = [
+  { id: "about", label: "About", Icon: AboutIcon },
+  { id: "skills", label: "Skills", Icon: SkillsIcon },
+  { id: "portfolio", label: "Portfolio", Icon: PortfolioIcon },
+  { id: "experience", label: "Experience", Icon: ExperienceIcon },
+  { id: "education", label: "Education", Icon: EducationIcon },
+];
+
 const Root = styled("div")(({ theme }) => ({
   flexGrow: 1,
   "& .appbar": {
@@ -63,51 +71,36 @@ export default function NavBar(props) {
     <Root data-testid="NavBar">
       <AppBar color="transparent" className={section ? "appbar" : "atTop"}>
         <Toolbar variant="dense">
-          <Typography variant="h6" component="a" href="/" className="title">
+          <Typography
+            variant="h6"
+            component="a"
+            href="/"
+            aria-label="Ryan SL Carpenter home"
+            className="title"
+          >
             RSLC
           </Typography>
-          <ButtonGroup
-            variant="text"
-            color="primary"
-            disableRipple
-            className="buttonGroup"
-          >
-            <Button
-              component="a"
-              href="/#about"
-              className={section === "about" ? "scrolledTo" : undefined}
+          <nav aria-label="Main">
+            <ButtonGroup
+              variant="text"
+              color="primary"
+              disableRipple
+              className="buttonGroup"
             >
-              {narrow ? <AboutIcon /> : "About"}
-            </Button>
-            <Button
-              component="a"
-              href="/#skills"
-              className={section === "skills" ? "scrolledTo" : undefined}
-            >
-              {narrow ? <SkillsIcon /> : "Skills"}
-            </Button>
-            <Button
-              component="a"
-              href="/#portfolio"
-              className={section === "portfolio" ? "scrolledTo" : undefined}
-            >
-              {narrow ? <PortfolioIcon /> : "Portfolio"}
-            </Button>
-            <Button
-              component="a"
-              href="/#experience"
-              className={section === "experience" ? "scrolledTo" : undefined}
-            >
-              {narrow ? <ExperienceIcon /> : "Experience"}
-            </Button>
-            <Button
-              component="a"
-              href="/#education"
-              className={section === "education" ? "scrolledTo" : undefined}
-            >
-              {narrow ? <EducationIcon /> : "Education"}
-            </Button>
-          </ButtonGroup>
+              {sections.map(({ id, label, Icon }) => (
+                <Button
+                  key={id}
+                  component="a"
+                  href={`/#${id}`}
+                  aria-label={label}
+                  aria-current={section === id ? "true" : undefined}
+                  className={section === id ? "scrolledTo" : undefined}
+                >
+                  {narrow ? <Icon /> : label}
+                </Button>
+              ))}
+            </ButtonGroup>
+          </nav>
         </Toolbar>
       </AppBar>
     </Root>

--- a/src/components/Portfolio.jsx
+++ b/src/components/Portfolio.jsx
@@ -84,8 +84,13 @@ const Portfolio = forwardRef((props, ref) => {
   const scrollUp = () => window.scrollTo(0, 0);
 
   return (
-    <Root ref={ref} data-testid="Portfolio">
-      <Typography variant="h4" component="h2" className="h2">
+    <Root ref={ref} data-testid="Portfolio" aria-labelledby="portfolio-heading">
+      <Typography
+        variant="h4"
+        component="h2"
+        id="portfolio-heading"
+        className="h2"
+      >
         <a name="portfolio" href="#portfolio">
           Portfolio
         </a>
@@ -125,6 +130,7 @@ const Portfolio = forwardRef((props, ref) => {
                       component={Link}
                       to={`/projects/${tile.id}`}
                       onClick={scrollUp}
+                      aria-label={`View details for ${tile.title}`}
                     >
                       <ZoomIcon />
                     </Button>
@@ -135,6 +141,7 @@ const Portfolio = forwardRef((props, ref) => {
                         href={tile.demo}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`View live demo of ${tile.title}`}
                       >
                         <LinkIcon />
                       </Button>
@@ -146,6 +153,7 @@ const Portfolio = forwardRef((props, ref) => {
                         href={tile.github}
                         target="_blank"
                         rel="noopener noreferrer"
+                        aria-label={`View source for ${tile.title} on GitHub`}
                       >
                         <GitHubIcon />
                       </Button>

--- a/src/components/Skills.jsx
+++ b/src/components/Skills.jsx
@@ -31,8 +31,13 @@ const Root = styled("section")({
 
 const Skills = forwardRef((props, ref) => {
   return (
-    <Root ref={ref} data-testid="Skills">
-      <Typography variant="h4" component="h2" className="h2">
+    <Root ref={ref} data-testid="Skills" aria-labelledby="skills-heading">
+      <Typography
+        variant="h4"
+        component="h2"
+        id="skills-heading"
+        className="h2"
+      >
         <a name="skills" href="#skills">
           Skills
         </a>

--- a/src/entry-server.jsx
+++ b/src/entry-server.jsx
@@ -8,6 +8,13 @@ import Project from "./screens/Project";
 import { theme } from "./theme";
 import projects from "./content/projects.json";
 
+export const SITE_URL = "https://carpiediem.github.io";
+const PERSON_NAME = "Ryan SL Carpenter";
+
+function absoluteUrl(urlOrPath) {
+  return urlOrPath.startsWith("http") ? urlOrPath : `${SITE_URL}${urlOrPath}`;
+}
+
 // Renders each route eagerly (skipping App.jsx's client-only lazy-loaded
 // Project screen) since renderToString can't wait on Suspense/lazy to
 // resolve - it just flushes the fallback. That's fine here: this bundle
@@ -41,16 +48,47 @@ export function routes() {
 }
 
 export function metaFor(url) {
+  const canonical = absoluteUrl(url);
   const match = url.match(/^\/projects\/(.+)$/);
   const project = match && projects.find((p) => p.id === match[1]);
+
   if (!project) {
     return {
-      title: "Ryan SL Carpenter",
+      title: PERSON_NAME,
       description: "Personal web site of Ryan SL Carpenter",
+      canonical,
+      image: absoluteUrl("/img/ryan.jpg"),
+      type: "website",
+      structuredData: {
+        "@context": "https://schema.org",
+        "@type": "Person",
+        name: PERSON_NAME,
+        jobTitle: "Software Engineer & Entrepreneur",
+        url: canonical,
+        image: absoluteUrl("/img/ryan.jpg"),
+        sameAs: [
+          "https://www.linkedin.com/in/ryanscarpenter/",
+          "https://github.com/carpiediem/",
+          "https://angel.co/u/ryanslcarpenter",
+          "https://stackoverflow.com/users/1811952/carpiediem",
+        ],
+      },
     };
   }
+
   return {
-    title: `${project.title} - Ryan SL Carpenter`,
+    title: `${project.title} - ${PERSON_NAME}`,
     description: project.title,
+    canonical,
+    image: absoluteUrl(project.img),
+    type: "article",
+    structuredData: {
+      "@context": "https://schema.org",
+      "@type": "CreativeWork",
+      name: project.title,
+      url: canonical,
+      image: absoluteUrl(project.img),
+      author: { "@type": "Person", name: PERSON_NAME, url: SITE_URL },
+    },
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -14,3 +14,18 @@ code {
   font-family:
     source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }
+
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: 0;
+  z-index: 1500;
+  padding: 12px 16px;
+  background: #006d77;
+  color: white;
+  text-decoration: none;
+}
+
+.skip-link:focus {
+  top: 0;
+}

--- a/src/screens/Home.jsx
+++ b/src/screens/Home.jsx
@@ -50,13 +50,18 @@ export default function Home() {
   });
 
   return (
-    <div data-testid="home">
+    <>
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
       <NavBar section={section} />
-      <About ref={aboutRef} />
-      <Skills ref={skillsRef} />
-      <Portfolio ref={portfolioRef} />
-      <Experience ref={experienceRef} />
-      <Education ref={educationRef} />
-    </div>
+      <main id="main-content" data-testid="home">
+        <About ref={aboutRef} />
+        <Skills ref={skillsRef} />
+        <Portfolio ref={portfolioRef} />
+        <Experience ref={experienceRef} />
+        <Education ref={educationRef} />
+      </main>
+    </>
   );
 }

--- a/src/screens/Project.jsx
+++ b/src/screens/Project.jsx
@@ -89,27 +89,32 @@ export default function Project({ initialContent } = {}) {
 
   return (
     <Root>
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
       <NavBar section={scrolled && "not top"} />
-      <Paper className="paper">
+      <Paper component="main" id="main-content" className="paper">
         <Grid container spacing={3}>
           <Grid size={{ sm: 6 }}>
             <img alt={summary.title} src={summary.img} className="img" />
             {summary.demo && (
               <IconButton
-                aria-label="view"
+                aria-label="View live demo"
                 component="a"
                 href={summary.demo}
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 <LinkIcon />
               </IconButton>
             )}
             {summary.github && (
               <IconButton
-                aria-label="view"
+                aria-label="View source on GitHub"
                 component="a"
                 href={summary.github}
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 <GitHubIcon />
               </IconButton>


### PR DESCRIPTION
## Summary

**SEO** (`src/entry-server.jsx`, `scripts/prerender.mjs`) - builds on #172's prerendering pipeline, which already gives every route real HTML at build time to inject this into:
- Per-route canonical URL, Open Graph tags, Twitter card tags, and JSON-LD structured data (`Person` on the home page, `CreativeWork` per project, reusing data already in `projects.json`).
- A generated `sitemap.xml` listing every route, referenced from `public/robots.txt`.

**Accessibility:**
- `NavBar`: refactored the five nearly-identical nav `Button` blocks into a data-driven map, wrapped them in a `<nav aria-label="Main">` landmark, added `aria-current` to the active section link, and gave every link - including the icon-only ones shown on narrow screens, which had **no accessible name at all** before - a matching `aria-label`. Also gave the site logo link a real accessible name instead of just "RSLC".
- Fixed three icon-only buttons in `Portfolio` (zoom/demo/GitHub) that had no accessible name whatsoever - screen reader users had no way to know what they did.
- Fixed generic `aria-label="view"` on `Project`'s demo/GitHub buttons to describe what they actually do.
- Added `rel="noopener noreferrer"` to every `target="_blank"` link that was missing it (About's 4 social links, Project's demo/GitHub links) - both a security fix (reverse tabnabbing) and a perf one.
- Fixed About's profile photo having `alt=""` (marking it decorative) when it's meaningful content.
- Added a "skip to main content" link on both Home and Project, landing on a proper `<main>` landmark (previously a plain `<div>`).
- Added `id`/`aria-labelledby` pairs between each section's heading and its landmark (About, Skills, Portfolio, Experience, Education), so landmark navigation announces "About region" etc. instead of just "region".

## Other things worth considering (not done here)
- **Heading semantics in the Experience/Education timeline**: `Job`/`School` mark the "years" text (e.g. "2020-Present") as an `<h3>`, purely for its visual weight - screen reader users navigating by heading end up with a list of date ranges rather than meaningful section titles. The company/school name would be a more useful heading, but it's currently only present as an image `alt` attribute, not visible/semantic text - fixing this well is more of a content/design call than a mechanical a11y fix, so I left it out of scope here.
- **A proper favicon set**: `index.html` has a commented-out `apple-touch-icon` pointing at a `logo192.png` that doesn't exist (a leftover from the Create React App days). Worth generating a real icon set at some point.
- **Automated a11y regression testing**: something like `vitest-axe` or `@axe-core/playwright` in CI would catch regressions on this front going forward instead of relying on manual review.

## Test plan
- [x] `npm test` - 36/36 passing
- [x] `npm run build` / `npm run lint` - clean
- [x] Verified headless via Playwright on both the home and a project page: single `<h1>`/landmark structure (`header` → `nav[aria-label="Main"]` → `main`), zero unlabeled icon-only interactive elements, all `<img>` have real alt text, skip link is the first tab stop and correctly focuses the `main` landmark
- [x] Spot-checked generated `sitemap.xml` and per-route OG/Twitter/JSON-LD tags in the build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)