### PR TITLE
Add accessibility scan workflow

### DIFF
--- a/.github/workflows/a11y-scan.yml
+++ b/.github/workflows/a11y-scan.yml
@@ -1,0 +1,48 @@
+name: Accessibility Scanner
+
+# Manual trigger only: this action files GitHub issues (and can open PRs via
+# Copilot) for whatever it finds, so it shouldn't run unattended on every
+# push. Run it from the Actions tab when you want a fresh scan.
+# https://github.com/github/accessibility-scanner
+on: workflow_dispatch
+
+permissions:
+  contents: read
+
+jobs:
+  list_urls:
+    runs-on: ubuntu-latest
+    outputs:
+      urls: ${{ steps.list.outputs.urls }}
+    steps:
+      - name: List URLs from the deployed sitemap
+        id: list
+        run: |
+          urls="$(curl -fsSL https://carpiediem.github.io/sitemap.xml | grep -o '<loc>[^<]*</loc>' | sed 's/<loc>//;s#</loc>##')"
+          {
+            echo "urls<<EOF"
+            echo "$urls"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+  accessibility_scanner:
+    needs: list_urls
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: github/accessibility-scanner@v3
+        with:
+          urls: ${{ needs.list_urls.outputs.urls }}
+          repository: ${{ github.repository }}
+          # A fine-grained PAT with contents:write, issues:write,
+          # pull-requests:write, actions:write, and metadata:read on this
+          # repo, added as a repository secret. The default GITHUB_TOKEN
+          # can't be used here. See the action's README for details:
+          # https://github.com/github/accessibility-scanner#2-create-a-token-and-add-a-secret
+          token: ${{ secrets.A11Y_SCANNER_TOKEN }}
+          cache_key: a11y-scan-results-carpiediem.github.io.json
+          include_screenshots: true
+          # Set to true if this repo doesn't have GitHub Copilot enabled,
+          # to skip auto-assigning filed issues to it.
+          # skip_copilot_assignment: true


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/a11y-scan.yml`, using [github/accessibility-scanner](https://github.com/github/accessibility-scanner) to scan the live site and file GitHub issues for what it finds (optionally proposing fixes via Copilot).
- URLs to scan are pulled dynamically from the deployed `sitemap.xml` (added in #173) via a small `list_urls` job, rather than hardcoded - stays in sync automatically as projects are added/removed.
- Manual trigger (`workflow_dispatch`) only, not on every push. The action's side effects (filing issues, potentially opening PRs) shouldn't happen unattended without a first look at what it finds - you can always add a `schedule` trigger later once you're happy with the results.

## Before this can run
The action requires a fine-grained PAT as a repository secret named `A11Y_SCANNER_TOKEN` - the default `GITHUB_TOKEN` isn't sufficient. This is an admin-only step I can't do myself:

1. Create a fine-grained PAT scoped to this repo with `contents:write`, `issues:write`, `pull-requests:write`, `actions:write`, and `metadata:read`.
2. Add it as a repository secret named `A11Y_SCANNER_TOKEN` under **Settings > Secrets and variables > Actions**.

If this repo doesn't have GitHub Copilot enabled, you may also want to uncomment `skip_copilot_assignment: true` in the workflow so it doesn't try to auto-assign filed issues to Copilot.

## Test plan
- [x] YAML validated (parses correctly, matches the action's documented input shape)
- [x] Verified the sitemap-parsing shell command against the live `https://carpiediem.github.io/sitemap.xml` - correctly extracts all 17 URLs
- [ ] Can't fully dry-run this without the `A11Y_SCANNER_TOKEN` secret in place - recommend triggering it manually once the secret is added to confirm end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)