### PR TITLE
Derive project meta descriptions from write-up content

### DIFF
--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -56,6 +56,8 @@ function outputPathFor(url) {
     : path.join(buildDir, url.replace(/^\/+/, ""), "index.html");
 }
 
+const PLACEHOLDER_CONTENT = "<p>TBD</p>";
+
 // Project.jsx loads its write-up text asynchronously (see that file), which
 // renderToString can't wait on - so read the file directly here and hand it
 // to entry-server.jsx to render synchronously as the initial content.
@@ -68,8 +70,36 @@ async function writeUpContentFor(url) {
       "utf-8",
     );
   } catch {
-    return "<p>TBD</p>";
+    return PLACEHOLDER_CONTENT;
   }
+}
+
+const HTML_ENTITIES = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+// A plain-text excerpt of a write-up, for use as a meta description -
+// falls back to undefined (letting the caller supply its own default) for
+// placeholder or empty content, which has nothing worth summarizing.
+function descriptionFromWriteUp(html, maxLength = 155) {
+  if (!html || html.trim() === PLACEHOLDER_CONTENT) return undefined;
+
+  const text = html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&([a-z]+);/gi, (entity, name) => HTML_ENTITIES[name] ?? entity)
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!text) return undefined;
+  if (text.length <= maxLength) return text;
+
+  const truncated = text.slice(0, maxLength + 1);
+  const lastSpace = truncated.lastIndexOf(" ");
+  return `${truncated.slice(0, lastSpace > 0 ? lastSpace : maxLength).trimEnd()}…`;
 }
 
 function sitemapFor(urls, siteUrl) {
@@ -90,6 +120,11 @@ async function main() {
     const writeUpContent = await writeUpContentFor(url);
     const appHtml = render(url, { writeUpContent });
     const meta = metaFor(url);
+    const excerpt = descriptionFromWriteUp(writeUpContent);
+    if (excerpt) {
+      meta.description = excerpt;
+      meta.structuredData.description = excerpt;
+    }
 
     const html = template
       .replace('<div id="root"></div>', `<div id="root">${appHtml}</div>`)

--- a/src/components/Portfolio.jsx
+++ b/src/components/Portfolio.jsx
@@ -35,7 +35,6 @@ const Root = styled("section")(({ theme }) => ({
   "& .gridList": {
     // Promote the list into his own layer on Chrome. This cost memory but helps keeping high FPS.
     transform: "translateZ(0)",
-    overflowY: "hidden",
   },
   "& .tile": {
     "& .MuiImageListItemBar-titleWrap": {

--- a/src/components/Portfolio.jsx
+++ b/src/components/Portfolio.jsx
@@ -35,6 +35,7 @@ const Root = styled("section")(({ theme }) => ({
   "& .gridList": {
     // Promote the list into his own layer on Chrome. This cost memory but helps keeping high FPS.
     transform: "translateZ(0)",
+    overflowY: "hidden",
   },
   "& .tile": {
     "& .MuiImageListItemBar-titleWrap": {


### PR DESCRIPTION
## Summary
Project pages previously reused the project title as both `<title>` and meta description, so search results/social previews for e.g. "Game of Thrones Map with Spoiler Control" showed that same phrase twice with nothing about what the project actually is.

`scripts/prerender.mjs` now strips tags/entities from each write-up's HTML (already read synchronously there for SSR - see #172) and uses the first ~155 characters, truncated at a word boundary, as the description - for the meta tag, Open Graph/Twitter description, and the `CreativeWork` structured data added in #173. Falls back to the existing title-based description from `entry-server.jsx`'s `metaFor()` when a write-up is just the `<p>TBD</p>` placeholder or otherwise empty.

Spot-checked a handful of generated descriptions and they read naturally, e.g.:
- easyship-portals: "In addition to managing the development of new features in Easyship's primary application (and migrating it from AngularJS to React), I created the starter…"
- mtrmaps: "Time-Scaled Maps I was intrigued by the time-scaled diagrams of Boston's & DC's subway lines and commuter rail created by Peter Dunn of Stone Brown Design…"

One known cosmetic quirk: when a write-up's first paragraph has a quotation mark directly touching a tag boundary (no source whitespace), the naive tag-stripping can leave a stray space next to the quote mark (visible in the gameofthrones example). Harmless, but not pixel-perfect - a fuller HTML-to-text parser would avoid it if it ever bothers anyone.

## Test plan
- [x] `npm test` - 36/36 passing
- [x] `npm run build` / `npm run lint` - clean
- [x] Spot-checked generated `<meta name="description">`, `og:description`, `twitter:description`, and structured-data `description` across several project pages, plus the placeholder-content fallback (watermargin, whose write-up is just `<p>TBD</p>`) still uses the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)