### PR TITLE
Fix NavBar color-contrast on project pages

### DIFF
--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -58,7 +58,7 @@ const Root = styled("div")(({ theme }) => ({
   },
   "& .atTop": {
     backgroundColor: "transparent",
-    color: "rgba(255, 255, 255, 0.7)",
+    color: "rgba(255, 255, 255, 0.85)",
     boxShadow: "none",
   },
 }));


### PR DESCRIPTION
## Summary
Fixes 14 open accessibility issues, all the same root cause: NavBar's "About/Skills/Portfolio/Experience/Education" links use the shared `atTop` state (transparent `AppBar`, `rgba(255, 255, 255, 0.7)` text) on every page. On the home page that sits over About's dark photo; on every project page it sits over `Project.jsx`'s solid dark teal background (`primary.main`, #006d77) instead. That combination blends to ~3.83:1 contrast - under WCAG AA's 4.5:1 - and since NavBar is shared, it was flagged identically on all 14 project pages.

Computed the fix directly: bumping the text opacity from 0.7 to 0.85 clears ~4.87:1 against that teal background. Since increasing opacity only ever raises contrast, this can't regress the home-page photo-background case either.

Closes #183, #185, #189, #192, #194, #196, #199, #201, #203, #204, #208, #212, #213, #215

## Test plan
- [x] `npm test` - 36/36 passing
- [x] `npm run build` / `npm run lint` - clean
- [x] Verified via Playwright against a built project page that the nav link's computed color is `rgba(255, 255, 255, 0.85)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)