### PR TITLE
Add alt text to write-up images

### DIFF
--- a/src/content/emotics.html
+++ b/src/content/emotics.html
@@ -13,6 +13,7 @@
 <img
   src="/img/emotics-tech-stack.png"
   style="float: right; height: 10em; margin: 0 0 5px 5px"
+  alt="Diagram of the Emotics AWS architecture: a load balancer routing to EC2 instances across two availability zones, backed by RDS, with CloudFront serving the console front-end"
 />
 
 <p>

--- a/src/content/mtrmaps.html
+++ b/src/content/mtrmaps.html
@@ -62,6 +62,7 @@
   ><img
     src="/img/hk-mtr-swapped-translations-transliterations.png"
     style="float: right; height: 10em; margin: 0 0 5px 5px"
+    alt="Thumbnail of the MTR map with each station's translated and transliterated names swapped"
 /></a>
 <p>
   Each station in the MTR has a name in Chinese and English. For some, the names
@@ -85,6 +86,7 @@
   ><img
     src="/img/mtr-station-colors.png"
     style="float: right; height: 10em; margin: 0 0 5px 5px"
+    alt="Thumbnail of the MTR map highlighting each station's assigned color"
 /></a>
 <p>
   Hong Kong's MTR may not have the grand passageways of St. Petersburg's subway
@@ -106,6 +108,7 @@
   ><img
     src="/img/mtr-aerial-zoom.jpg"
     style="float: right; height: 10em; margin: 0 0 5px 5px"
+    alt="Thumbnail of the MTR lines and stations plotted onto an aerial photo of Victoria Harbour"
 /></a>
 <p>
   Another different perspective of the MTR network,

--- a/src/content/nathan-road-solar-system.html
+++ b/src/content/nathan-road-solar-system.html
@@ -14,6 +14,7 @@
   <img
     src="/img/nathan-road-solar-system-jupiter.png"
     style="float: right; height: 10em; margin: 0 0 5px 5px"
+    alt="Jupiter worksheet slide from the Nathan Road solar system scale model, with its stats and a street map showing its location"
   />
 </a>
 <p>

--- a/src/content/sohobusmap.html
+++ b/src/content/sohobusmap.html
@@ -15,7 +15,11 @@
 <a
   href="http://www.tfl.gov.uk/gettingaround/maps/buses/kensington-chelsea.aspx"
 >
-  <img src="/img/nottinghill.png" style="float: right; padding: 5px" />
+  <img
+    src="/img/nottinghill.png"
+    style="float: right; padding: 5px"
+    alt="Transport for London bus spider map for the area around Notting Hill Gate"
+  />
 </a>
 <p>
   Peter's work made me think that Hong Kong might be good place to implement
@@ -56,7 +60,11 @@
   I would love to see a map like this made for each MTR station and posted on
   the wall. It would fill in an important information gap for passengers.
 </p>
-<img src="/img/centralMTRmap.jpg" style="float: right; padding: 5px" />
+<img
+  src="/img/centralMTRmap.jpg"
+  style="float: right; padding: 5px"
+  alt="Photo of an MTR station's exit and street map signage board"
+/>
 <ul>
   <li>
     <a


### PR DESCRIPTION
## Summary
Fixes 4 open accessibility issues covering 7 images across 4 project write-ups. Unlike the earlier a11y fixes (shared component styling), these are individual `<img>` tags in `src/content/*.html` with no `alt` attribute at all - each needed real alt text written based on what the image actually shows and its surrounding context. Viewed each image to write accurate descriptions rather than guessing from filenames:

- **nathan-road-solar-system.html**: the Jupiter worksheet slide (stats + street map location) that links to the full slide deck
- **emotics.html**: the AWS architecture diagram (load balancer, EC2 across two AZs, RDS, CloudFront)
- **sohobusmap.html**: the TfL bus spider map example that inspired the project, and a photo of an MTR station's exit/street signage board
- **mtrmaps.html**: three linked map thumbnails - swapped station name translations, station-color map, and the aerial Victoria Harbour view

Closes #186, #190, #205, #209

## Test plan
- [x] `npm test` - 36/36 passing
- [x] `npm run build` / `npm run lint` - clean
- [x] Verified each image's `alt` attribute renders correctly in the prerendered build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)