### PR TITLE
Migrate JSX components and entry points to TypeScript

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Run ESLint
         run: npm run lint
 
+      - name: Run the type checker
+        run: npm run typecheck
+
       - name: Run the tests
         run: npm test -- --coverage
 

--- a/index.html
+++ b/index.html
@@ -41,6 +41,6 @@
     </script>
     <script async src="https://www.google-analytics.com/analytics.js"></script>
     <script async src="/autotrack.js"></script>
-    <script type="module" src="/src/index.jsx"></script>
+    <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,13 @@
         "@testing-library/jest-dom": "^7.0.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.5",
+        "@types/lodash": "^4.17.25",
+        "@types/node": "^26.2.0",
+        "@types/react": "^18.3.31",
+        "@types/react-dom": "^18.3.7",
+        "@types/react-router-dom": "^5.3.3",
+        "@typescript-eslint/eslint-plugin": "^8.67.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "@vitejs/plugin-react": "^6.0.5",
         "@vitest/coverage-v8": "^4.0.0",
         "eslint": "^8.57.1",
@@ -36,6 +43,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "jsdom": "^28.0.0",
         "prettier": "3.9.6",
+        "typescript": "^5.9.3",
         "vite": "^8.2.1",
         "vitest": "^4.0.0"
       }
@@ -1607,6 +1615,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.25.tgz",
+      "integrity": "sha512-+K1NIO8I+F9/wNulfVvu23QYd0Pe9/OCqRrim4NoYIf1VoEDL90Ve4ClzpyqBLc7NpGGWRvYNCKZ1BE/Jpf8dQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -1620,13 +1652,46 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.18",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
-      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -1636,6 +1701,301 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.67.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.67.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -7041,6 +7401,19 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -7145,6 +7518,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -7173,6 +7560,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/universalify": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,13 @@
     "@testing-library/jest-dom": "^7.0.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.5",
+    "@types/lodash": "^4.17.25",
+    "@types/node": "^26.2.0",
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
+    "@types/react-router-dom": "^5.3.3",
+    "@typescript-eslint/eslint-plugin": "^8.67.0",
+    "@typescript-eslint/parser": "^8.67.0",
     "@vitejs/plugin-react": "^6.0.5",
     "@vitest/coverage-v8": "^4.0.0",
     "eslint": "^8.57.1",
@@ -37,14 +44,16 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "jsdom": "^28.0.0",
     "prettier": "3.9.6",
+    "typescript": "^5.9.3",
     "vite": "^8.2.1",
     "vitest": "^4.0.0"
   },
   "scripts": {
     "start": "vite",
-    "build": "vite build && vite build --ssr src/entry-server.jsx --outDir build-ssr && node scripts/prerender.mjs",
+    "build": "vite build && vite build --ssr src/entry-server.tsx --outDir build-ssr && node scripts/prerender.mjs",
     "test": "vitest run",
-    "lint": "eslint . --ext .js,.jsx",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "predeploy": "npm run build",
@@ -81,7 +90,9 @@
       {
         "files": [
           "**/*.test.js",
-          "**/*.test.jsx"
+          "**/*.test.jsx",
+          "**/*.test.ts",
+          "**/*.test.tsx"
         ],
         "globals": {
           "test": "readonly",
@@ -93,6 +104,21 @@
           "beforeAll": "readonly",
           "afterAll": "readonly",
           "vi": "readonly"
+        }
+      },
+      {
+        "files": [
+          "**/*.ts",
+          "**/*.tsx"
+        ],
+        "parser": "@typescript-eslint/parser",
+        "plugins": [
+          "@typescript-eslint"
+        ],
+        "rules": {
+          "no-unused-vars": "off",
+          "@typescript-eslint/no-unused-vars": "error",
+          "no-undef": "off"
         }
       }
     ],

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,6 +1,6 @@
 // Renders every route to static HTML after the client build, so GitHub
 // Pages serves real content (crawlers, no-JS clients, first paint)
-// instead of an empty <div id="root">. src/index.jsx hydrates this markup
+// instead of an empty <div id="root">. src/index.tsx hydrates this markup
 // in place rather than re-rendering from scratch.
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -57,9 +57,9 @@ function outputPathFor(url) {
 
 const PLACEHOLDER_CONTENT = "<p>TBD</p>";
 
-// Project.jsx loads its write-up text asynchronously (see that file), which
+// Project.tsx loads its write-up text asynchronously (see that file), which
 // renderToString can't wait on - so read the file directly here and hand it
-// to entry-server.jsx to render synchronously as the initial content.
+// to entry-server.tsx to render synchronously as the initial content.
 async function writeUpContentFor(url) {
   const match = url.match(/^\/projects\/(.+)$/);
   if (!match) return undefined;
@@ -125,7 +125,7 @@ async function main() {
       meta.structuredData.description = excerpt;
     }
 
-    // Project.jsx's write-up content loads asynchronously client-side (see
+    // Project.tsx's write-up content loads asynchronously client-side (see
     // that file), which would otherwise start empty on the client's first
     // render - a real hydration mismatch against this prerendered markup,
     // not just a redundant fetch. Embedding it here lets the client's

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import { vi } from "vitest";
 import App from "./App";
@@ -16,7 +15,7 @@ test("renders Home screen, by default", () => {
 // throwing. This checks for that failure class specifically, rather
 // than requiring zero console output, since unrelated deprecation
 // warnings are expected noise on older dependency versions.
-function expectNoInvalidElementTypeErrors(path) {
+function expectNoInvalidElementTypeErrors(path: string) {
   const spy = vi.spyOn(console, "error").mockImplementation(() => {});
   window.history.pushState({}, "", path);
   render(<App />);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import "core-js/stable";
 import "regenerator-runtime/runtime";
-import React from "react";
 import { BrowserRouter, Switch, Route } from "react-router-dom";
 import { ThemeProvider } from "@mui/material/styles";
 

--- a/src/components/About.test.tsx
+++ b/src/components/About.test.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+import { vi } from "vitest";
 import { render, fireEvent } from "@testing-library/react";
 import About from "./About";
 
 beforeEach(() => {
-  global.ga.mockClear();
+  vi.mocked(window.ga!).mockClear();
 });
 
 test("renders the About section", () => {
@@ -14,7 +14,7 @@ test("renders the About section", () => {
 test("tracks a GA event when the resume download button is clicked", () => {
   const { getByText } = render(<About />);
   fireEvent.click(getByText("Download Resume"));
-  expect(global.ga).toHaveBeenCalledWith(
+  expect(window.ga).toHaveBeenCalledWith(
     "send",
     "event",
     "File",
@@ -26,7 +26,7 @@ test("tracks a GA event when the resume download button is clicked", () => {
 test("tracks a GA event when the email address is clicked", () => {
   const { getByText } = render(<About />);
   fireEvent.click(getByText("ryan.sl.carpenter@gmail.com"));
-  expect(global.ga).toHaveBeenCalledWith(
+  expect(window.ga).toHaveBeenCalledWith(
     "send",
     "event",
     "Link",

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,6 +1,4 @@
-/* global ga */
-
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { styled } from "@mui/material/styles";
 import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
@@ -12,13 +10,13 @@ import IconButton from "@mui/material/IconButton";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
 import ListItemText from "@mui/material/ListItemText";
-import Tooltip from "@mui/material/Tooltip";
+import Tooltip, { type TooltipProps } from "@mui/material/Tooltip";
 import LinkedInIcon from "@mui/icons-material/LinkedIn";
 import GitHubIcon from "@mui/icons-material/GitHub";
 
 import Introduction from "./Introduction";
 
-function ColorTooltip(props) {
+function ColorTooltip(props: TooltipProps) {
   return (
     <Tooltip
       {...props}
@@ -125,11 +123,11 @@ const Root = styled("div")(({ theme }) => ({
   "& .hello": { color: "black", fontSize: 20, fontWeight: 300 },
 }));
 
-const About = forwardRef((props, ref) => {
+const About = forwardRef<HTMLElement>((_props, ref) => {
   const triggerDownloadEvent = () =>
-    ga("send", "event", "File", "Download", "Resume");
+    window.ga?.("send", "event", "File", "Download", "Resume");
   const triggerEmailEvent = () =>
-    ga("send", "event", "Link", "Click", "Email Address");
+    window.ga?.("send", "event", "Link", "Click", "Email Address");
 
   return (
     <Root>
@@ -143,7 +141,7 @@ const About = forwardRef((props, ref) => {
           <CardContent className="content">
             <Grid container spacing={3}>
               <Grid size={{ sm: 5 }} className="item">
-                <a name="about" href="#about">
+                <a id="about" href="#about">
                   <img
                     alt="Ryan SL Carpenter"
                     src="/img/ryan.jpg"

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,10 +1,13 @@
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { styled } from "@mui/material/styles";
 import Timeline from "@mui/lab/Timeline";
 import Typography from "@mui/material/Typography";
 
 import School from "./School";
-import schools from "../content/schools.json";
+import schoolsData from "../content/schools.json";
+import type { School as SchoolData } from "../content/types";
+
+const schools = schoolsData as SchoolData[];
 
 const Root = styled("section")({
   maxWidth: 960,
@@ -27,7 +30,7 @@ const Root = styled("section")({
   },
 });
 
-const Education = forwardRef((props, ref) => {
+const Education = forwardRef<HTMLElement>((_props, ref) => {
   return (
     <Root ref={ref} data-testid="Education" aria-labelledby="education-heading">
       <Typography
@@ -36,12 +39,12 @@ const Education = forwardRef((props, ref) => {
         id="education-heading"
         className="h2"
       >
-        <a name="education" href="#education">
+        <a id="education" href="#education">
           Education
         </a>
       </Typography>
 
-      <Timeline align="alternate">
+      <Timeline position="alternate">
         {schools.map((school) => (
           <School key={school.years} {...school} />
         ))}

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,10 +1,13 @@
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { styled } from "@mui/material/styles";
 import Timeline from "@mui/lab/Timeline";
 import Typography from "@mui/material/Typography";
 
 import Job from "./Job";
-import jobs from "../content/jobs.json";
+import jobsData from "../content/jobs.json";
+import type { Job as JobData } from "../content/types";
+
+const jobs = jobsData as JobData[];
 
 const Root = styled("section")({
   maxWidth: 960,
@@ -28,7 +31,7 @@ const Root = styled("section")({
   },
 });
 
-const Experience = forwardRef((props, ref) => {
+const Experience = forwardRef<HTMLElement>((_props, ref) => {
   return (
     <Root
       ref={ref}
@@ -41,12 +44,12 @@ const Experience = forwardRef((props, ref) => {
         id="experience-heading"
         className="h2"
       >
-        <a name="experience" href="#experience">
+        <a id="experience" href="#experience">
           Work Experience
         </a>
       </Typography>
 
-      <Timeline align="alternate">
+      <Timeline position="alternate">
         {jobs.map((job) => (
           <Job key={job.years} {...job} />
         ))}

--- a/src/components/Introduction.test.tsx
+++ b/src/components/Introduction.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import Introduction from "./Introduction";
 

--- a/src/components/Introduction.tsx
+++ b/src/components/Introduction.tsx
@@ -18,13 +18,16 @@ const Root = styled("div")({
   "& .role": { fontWeight: 400 },
 });
 
-export default function Introduction(props) {
-  const {
-    // bubble = 'Hey, there',
-    name = "John Smith",
-    role = "Human Person",
-  } = props;
+interface IntroductionProps {
+  // bubble?: React.ReactNode;
+  name?: React.ReactNode;
+  role?: React.ReactNode;
+}
 
+export default function Introduction({
+  name = "John Smith",
+  role = "Human Person",
+}: IntroductionProps) {
   return (
     <Root>
       {/* <SpeechBubble text={bubble} /> */}

--- a/src/components/Job.test.tsx
+++ b/src/components/Job.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import Job from "./Job";
 

--- a/src/components/Job.tsx
+++ b/src/components/Job.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { styled } from "@mui/material/styles";
 import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
@@ -8,6 +7,8 @@ import TimelineConnector from "@mui/lab/TimelineConnector";
 import TimelineContent from "@mui/lab/TimelineContent";
 import TimelineDot from "@mui/lab/TimelineDot";
 import Typography from "@mui/material/Typography";
+
+import type { Job as JobData } from "../content/types";
 
 const Root = styled(TimelineItem)(({ theme }) => ({
   flexDirection: "row-reverse",
@@ -84,7 +85,7 @@ const Root = styled(TimelineItem)(({ theme }) => ({
   },
 }));
 
-export default function Job(props) {
+export default function Job(props: Partial<JobData>) {
   const {
     years = "THEN - NOW",
     company = "Evercorp",
@@ -110,14 +111,14 @@ export default function Job(props) {
       <TimelineContent>
         <Paper elevation={3} className="paper">
           <span className="arrow"></span>
-          <Stack sx={margin && { "& img.logo": { margin } }}>
+          <Stack sx={margin ? { "& img.logo": { margin } } : undefined}>
             <Typography variant="h6" component="h3" className="years">
               {years}
             </Typography>
             <a href={url} target="_blank" rel="noopener noreferrer">
               <img src={logo} alt={company} className="logo" />
             </a>
-            <Typography variant="overline" display="block">
+            <Typography variant="overline" sx={{ display: "block" }}>
               {role}
             </Typography>
           </Stack>

--- a/src/components/NavBar.test.tsx
+++ b/src/components/NavBar.test.tsx
@@ -1,10 +1,9 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import NavBar from "./NavBar";
 
 const originalInnerWidth = window.innerWidth;
 
-function setInnerWidth(width) {
+function setInnerWidth(width: number) {
   Object.defineProperty(window, "innerWidth", {
     configurable: true,
     writable: true,

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { styled } from "@mui/material/styles";
 import AppBar from "@mui/material/AppBar";
 import Toolbar from "@mui/material/Toolbar";
@@ -63,7 +63,11 @@ const Root = styled("div")(({ theme }) => ({
   },
 }));
 
-export default function NavBar(props) {
+interface NavBarProps {
+  section?: string | false | null;
+}
+
+export default function NavBar(props: NavBarProps) {
   const { section } = props;
   const [narrow, setNarrow] = useState(false);
 

--- a/src/components/Portfolio.test.tsx
+++ b/src/components/Portfolio.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { vi } from "vitest";
 import { fireEvent, render } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -31,7 +30,7 @@ test("renders a featured project with tags, a demo link, and a GitHub link", () 
     </MemoryRouter>,
   );
   expect(getByText("Featured Project")).toBeInTheDocument();
-  expect(container.querySelector(".tags").textContent).toBe("featured, web");
+  expect(container.querySelector(".tags")?.textContent).toBe("featured, web");
   expect(
     container.querySelector('a[href="https://example.com/demo"]'),
   ).toBeInTheDocument();
@@ -59,9 +58,11 @@ test("scrolls to the top when the zoom link is clicked", () => {
     </MemoryRouter>,
   );
 
-  fireEvent.click(
-    container.querySelector('a[href="/projects/featured-project"]'),
+  const zoomLink = container.querySelector(
+    'a[href="/projects/featured-project"]',
   );
+  expect(zoomLink).toBeInTheDocument();
+  fireEvent.click(zoomLink!);
 
   expect(window.scrollTo).toHaveBeenCalledWith(0, 0);
 });

--- a/src/components/Portfolio.tsx
+++ b/src/components/Portfolio.tsx
@@ -11,7 +11,10 @@ import LinkIcon from "@mui/icons-material/Link";
 import GitHubIcon from "@mui/icons-material/GitHub";
 
 // import Skill from './Skill';
-import projects from "../content/projects.json";
+import projectsData from "../content/projects.json";
+import type { ProjectSummary } from "../content/types";
+
+const projects = projectsData as ProjectSummary[];
 
 const Root = styled("section")(({ theme }) => ({
   maxWidth: 960,
@@ -81,7 +84,7 @@ const Root = styled("section")(({ theme }) => ({
   },
 }));
 
-const Portfolio = forwardRef((props, ref) => {
+const Portfolio = forwardRef<HTMLElement>((_props, ref) => {
   const scrollUp = () => window.scrollTo(0, 0);
 
   return (
@@ -92,7 +95,7 @@ const Portfolio = forwardRef((props, ref) => {
         id="portfolio-heading"
         className="h2"
       >
-        <a name="portfolio" href="#portfolio">
+        <a id="portfolio" href="#portfolio">
           Portfolio
         </a>
       </Typography>

--- a/src/components/School.test.tsx
+++ b/src/components/School.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import School from "./School";
 

--- a/src/components/School.tsx
+++ b/src/components/School.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { styled } from "@mui/material/styles";
 import Paper from "@mui/material/Paper";
 import TimelineItem from "@mui/lab/TimelineItem";
@@ -8,6 +7,8 @@ import TimelineContent from "@mui/lab/TimelineContent";
 // import TimelineOppositeContent from '@mui/lab/TimelineOppositeContent';
 import TimelineDot from "@mui/lab/TimelineDot";
 import Typography from "@mui/material/Typography";
+
+import type { School as SchoolData } from "../content/types";
 
 const Root = styled(TimelineItem)(({ theme }) => ({
   flexDirection: "row-reverse",
@@ -90,7 +91,7 @@ const Root = styled(TimelineItem)(({ theme }) => ({
   "& .school": { color: "#757575", textDecoration: "none" },
 }));
 
-export default function School(props) {
+export default function School(props: Partial<SchoolData>) {
   const {
     years = "THEN - NOW",
     school = "School of Hard Knocks",
@@ -122,7 +123,7 @@ export default function School(props) {
           </Typography>
           <Typography
             variant="overline"
-            display="block"
+            sx={{ display: "block" }}
             component="a"
             href={url}
             target="_blank"

--- a/src/components/Skill.test.tsx
+++ b/src/components/Skill.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import Skill from "./Skill";
 

--- a/src/components/Skill.tsx
+++ b/src/components/Skill.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { styled } from "@mui/material/styles";
 import Icon from "@mui/material/Icon";
 import Typography from "@mui/material/Typography";
@@ -23,13 +22,17 @@ const Root = styled("div")(({ theme }) => ({
   // description: { textAlign: 'justify' },
 }));
 
-export default function Skill(props) {
-  const {
-    iconClass = "far fa-lightbulb",
-    name = "Skill",
-    description = "I am awesome.",
-  } = props; // eslint-disable-line no-unused-vars
+interface SkillProps {
+  iconClass?: string;
+  name?: string;
+  description?: string;
+}
 
+export default function Skill({
+  iconClass = "far fa-lightbulb",
+  name = "Skill",
+  description = "I am awesome.",
+}: SkillProps) {
   return (
     <Root>
       <Icon className={iconClass} />

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,10 +1,13 @@
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 import { styled } from "@mui/material/styles";
 import Grid from "@mui/material/Grid";
 import Typography from "@mui/material/Typography";
 
 import Skill from "./Skill";
-import skills from "../content/skills.json";
+import skillsData from "../content/skills.json";
+import type { Skill as SkillData } from "../content/types";
+
+const skills = skillsData as SkillData[];
 
 const Root = styled("section")({
   maxWidth: 960,
@@ -29,7 +32,7 @@ const Root = styled("section")({
   },
 });
 
-const Skills = forwardRef((props, ref) => {
+const Skills = forwardRef<HTMLElement>((_props, ref) => {
   return (
     <Root ref={ref} data-testid="Skills" aria-labelledby="skills-heading">
       <Typography
@@ -38,7 +41,7 @@ const Skills = forwardRef((props, ref) => {
         id="skills-heading"
         className="h2"
       >
-        <a name="skills" href="#skills">
+        <a id="skills" href="#skills">
           Skills
         </a>
       </Typography>

--- a/src/components/SpeechBubble.test.tsx
+++ b/src/components/SpeechBubble.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { render } from "@testing-library/react";
 import SpeechBubble from "./SpeechBubble";
 

--- a/src/components/SpeechBubble.tsx
+++ b/src/components/SpeechBubble.tsx
@@ -31,8 +31,11 @@ const Root = styled("div")(({ theme }) => ({
   },
 }));
 
-export default function SpeechBubble(props) {
-  const { text } = props;
+interface SpeechBubbleProps {
+  text?: React.ReactNode;
+}
+
+export default function SpeechBubble({ text }: SpeechBubbleProps) {
   return (
     <Root>
       <span>{text}</span>

--- a/src/content/types.ts
+++ b/src/content/types.ts
@@ -1,0 +1,40 @@
+export interface Job {
+  years: string;
+  company: string;
+  url: string;
+  logo: string;
+  role: string;
+  description: string;
+  margin?: string;
+  side?: "right";
+  offset?: number;
+}
+
+export interface School {
+  years: string;
+  school: string;
+  url: string;
+  degree: string;
+  side?: "right";
+  offset?: number;
+  color?: "secondary";
+}
+
+export interface Skill {
+  name: string;
+  iconClass: string;
+  description: string;
+}
+
+export interface ProjectSummary {
+  id: string;
+  img: string;
+  title: string;
+  tags?: string[];
+  featured?: boolean;
+  github?: string;
+  demo?: string;
+  "private-github"?: string;
+  demo_tbd?: string;
+  old_demo?: string;
+}

--- a/src/entry-server.tsx
+++ b/src/entry-server.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { renderToString } from "react-dom/server";
 import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";
@@ -9,12 +8,36 @@ import { ThemeProvider } from "@mui/material/styles";
 import Home from "./screens/Home";
 import Project from "./screens/Project";
 import { theme } from "./theme";
-import projects from "./content/projects.json";
+import projectsData from "./content/projects.json";
+import type { ProjectSummary } from "./content/types";
+
+const projects = projectsData as ProjectSummary[];
 
 export const SITE_URL = "https://carpiediem.github.io";
 const PERSON_NAME = "Ryan SL Carpenter";
 
-function absoluteUrl(urlOrPath) {
+interface StructuredData {
+  "@context": string;
+  "@type": string;
+  name: string;
+  url: string;
+  image: string;
+  description?: string;
+  jobTitle?: string;
+  sameAs?: string[];
+  author?: { "@type": string; name: string; url: string };
+}
+
+export interface Meta {
+  title: string;
+  description: string;
+  canonical: string;
+  image: string;
+  type: "website" | "article";
+  structuredData: StructuredData;
+}
+
+function absoluteUrl(urlOrPath: string) {
   return urlOrPath.startsWith("http") ? urlOrPath : `${SITE_URL}${urlOrPath}`;
 }
 
@@ -36,7 +59,10 @@ function absoluteUrl(urlOrPath) {
 // there (it looks for them in <head>) and treats as a hydration mismatch.
 // "css" matches emotion's own default cache key, which MUI's styled()
 // uses automatically on the client with no CacheProvider needed there.
-export function render(url, { writeUpContent } = {}) {
+export function render(
+  url: string,
+  { writeUpContent }: { writeUpContent?: string } = {},
+) {
   const cache = createCache({ key: "css" });
   const { extractCriticalToChunks, constructStyleTagsFromChunks } =
     createEmotionServer(cache);
@@ -67,7 +93,7 @@ export function routes() {
   return ["/", ...projects.map((project) => `/projects/${project.id}`)];
 }
 
-export function metaFor(url) {
+export function metaFor(url: string): Meta {
   const canonical = absoluteUrl(url);
   const match = url.match(/^\/projects\/(.+)$/);
   const project = match && projects.find((p) => p.id === match[1]);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,14 @@
+export {};
+
+declare global {
+  interface Window {
+    // Google Analytics with Autotrack, loaded as a global script in
+    // index.html - see the comment there.
+    ga?: (...args: unknown[]) => void;
+
+    // Set by scripts/prerender.mjs for project routes, so Project's first
+    // client render matches what the server sent instead of starting
+    // empty - see Project.tsx.
+    __INITIAL_CONTENT__?: { id: string; html: string };
+  }
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,7 +4,7 @@ import "./index.css";
 import App from "./App";
 import * as serviceWorker from "./serviceWorker";
 
-const container = document.getElementById("root");
+const container = document.getElementById("root")!;
 const app = (
   <React.StrictMode>
     <App />

--- a/src/screens/Home.test.tsx
+++ b/src/screens/Home.test.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { vi } from "vitest";
 import { act, render, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -42,14 +41,15 @@ test("updates the active nav section when the page is scrolled", () => {
   const educationButton = within(getByTestId("NavBar"))
     .getByText("Education")
     .closest("a");
-  const initialClassName = educationButton.className;
+  expect(educationButton).toBeInTheDocument();
+  const initialClassName = educationButton!.className;
 
   act(() => {
     window.dispatchEvent(new Event("scroll"));
     vi.advanceTimersByTime(150);
   });
 
-  expect(educationButton.className).not.toBe(initialClassName);
+  expect(educationButton!.className).not.toBe(initialClassName);
 
   vi.useRealTimers();
 });

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -9,13 +9,13 @@ import Experience from "../components/Experience";
 import Education from "../components/Education";
 
 export default function Home() {
-  const [section, setSection] = useState(null);
+  const [section, setSection] = useState<string | null>(null);
 
-  const educationRef = useRef(null);
-  const experienceRef = useRef(null);
-  const portfolioRef = useRef(null);
-  const skillsRef = useRef(null);
-  const aboutRef = useRef(null);
+  const educationRef = useRef<HTMLElement>(null);
+  const experienceRef = useRef<HTMLElement>(null);
+  const portfolioRef = useRef<HTMLElement>(null);
+  const skillsRef = useRef<HTMLElement>(null);
+  const aboutRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     // The browser's native same-page anchor scroll only fires once, when
@@ -29,20 +29,20 @@ export default function Home() {
 
   useEffect(() => {
     // MUST BE IN REVERSE ORDER
-    const sections = [
+    const sections: [string, React.RefObject<HTMLElement | null>][] = [
       ["education", educationRef],
       ["experience", experienceRef],
       ["portfolio", portfolioRef],
       ["skills", skillsRef],
       ["about", aboutRef],
     ];
-    const breakpoints = sections.map(([key, ref]) => [
+    const breakpoints: [string, number][] = sections.map(([key, ref]) => [
       key,
-      window.scrollY + ref.current.getBoundingClientRect().top,
+      window.scrollY + (ref.current?.getBoundingClientRect().top ?? 0),
     ]);
     const listener = debounce(() => {
       const section = breakpoints.find(([, y]) => window.scrollY + 99 >= y);
-      setSection(section && section[0]);
+      setSection(section ? section[0] : null);
     }, 100);
 
     window.addEventListener("scroll", listener);

--- a/src/screens/Project.test.tsx
+++ b/src/screens/Project.test.tsx
@@ -1,10 +1,9 @@
-import React from "react";
 import { vi } from "vitest";
 import { act, render } from "@testing-library/react";
 import { MemoryRouter, Route } from "react-router-dom";
 import Project from "./Project";
 
-function setScrollY(value) {
+function setScrollY(value: number) {
   Object.defineProperty(window, "scrollY", {
     configurable: true,
     writable: true,
@@ -40,8 +39,9 @@ test("marks the nav as scrolled once the page is scrolled past the top", () => {
     </MemoryRouter>,
   );
 
-  const appBar = getByTestId("NavBar").firstChild;
-  const initialClassName = appBar.className;
+  const appBar = getByTestId("NavBar").firstChild as HTMLElement | null;
+  expect(appBar).toBeInTheDocument();
+  const initialClassName = appBar!.className;
 
   setScrollY(100);
   act(() => {
@@ -49,7 +49,7 @@ test("marks the nav as scrolled once the page is scrolled past the top", () => {
     vi.advanceTimersByTime(150);
   });
 
-  expect(appBar.className).not.toBe(initialClassName);
+  expect(appBar!.className).not.toBe(initialClassName);
 
   vi.useRealTimers();
 });

--- a/src/screens/Project.tsx
+++ b/src/screens/Project.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import { useParams, Redirect } from "react-router-dom";
 import debounce from "lodash/debounce";
 import { styled } from "@mui/material/styles";
@@ -10,9 +10,12 @@ import LinkIcon from "@mui/icons-material/Link";
 import GitHubIcon from "@mui/icons-material/GitHub";
 
 import NavBar from "../components/NavBar";
-import projects from "../content/projects.json";
+import projectsData from "../content/projects.json";
+import type { ProjectSummary } from "../content/types";
 
-const writeUps = import.meta.glob("../content/*.html", {
+const projects = projectsData as ProjectSummary[];
+
+const writeUps = import.meta.glob<string>("../content/*.html", {
   query: "?raw",
   import: "default",
 });
@@ -36,8 +39,12 @@ const Root = styled("div")(({ theme }) => ({
   },
 }));
 
-export default function Project({ initialContent } = {}) {
-  const { id } = useParams();
+interface ProjectProps {
+  initialContent?: string;
+}
+
+export default function Project({ initialContent }: ProjectProps = {}) {
+  const { id } = useParams<{ id: string }>();
   const [scrolled, setScrolled] = useState(false);
 
   const summary = projects.find((p) => p.id === id);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src", "scripts", "vite.config.js"]
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,8 +14,8 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],
-      include: ["src/**/*.{js,jsx}"],
-      exclude: ["src/index.jsx", "src/serviceWorker.js"],
+      include: ["src/**/*.{js,jsx,ts,tsx}"],
+      exclude: ["src/index.tsx", "src/serviceWorker.js"],
     },
   },
 });


### PR DESCRIPTION
## Summary
- Renames all remaining `.jsx` source files (components, screens, `App`, `index`, `entry-server`, and their tests) to `.tsx`, completing the TypeScript migration alongside the already-converted `tsconfig.json`, `global.d.ts`, and `content/types.ts`
- Fixes the type errors uncovered along the way: drops now-unnecessary `React` imports (react-jsx transform), swaps the deprecated anchor `name` attribute for `id`, updates MUI Lab's `Timeline` `align` prop to `position`, moves MUI `Typography`'s removed `display` prop into `sx`, and tightens a few implicit-`any`/nullable-DOM spots in tests
- Adds a `typecheck` script (`tsc --noEmit`) and wires it into CI, and updates `vite.config.js`, `index.html`, and `scripts/prerender.mjs` to reference the renamed `.tsx` entry points

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm test`
- [x] `npm run build` (client + SSR build, prerender of all 17 routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)